### PR TITLE
change to make xplatform compile windows exe bins

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ GZIP_ENV="-9n"
 if BUILD_BITCOIN_LIBS
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libbitcoinconsensus.pc
+libbitcoinconsensus_la_LDFLAGS = -no-undefined
 endif
 
 BITCOIND_BIN=$(top_builddir)/src/zerooned$(EXEEXT)


### PR DESCRIPTION
libtool: undefined symbols not allowed	in i686-pc-mingw32 shared
correction as suggested by
https://stackoverflow.com/questions/17487891/libtool-undefined-symbols-not-allowedin-i686-pc-mingw32-shared/22884787#22884787